### PR TITLE
Fixing link on member site setup instructions

### DIFF
--- a/projects/largo/umbrella-setup.md
+++ b/projects/largo/umbrella-setup.md
@@ -285,7 +285,7 @@ The default virtual machine has 384MB of RAM to be respectful of a range machine
 
 #### Rock on! But wait, you're not done.
 
-## [Complete Member Site Setup](../member-site-setup.md)
+## [Complete Member Site Setup](./child-themes/new-site.md)
 Each site in the Umbrella requires it's own brief setup before it can be used in a local development environment to remove production values.
 
 ## Sweet, now you're done


### PR DESCRIPTION
The link was 404. This fixes the link to the instructions for configuring sites in the network.