### PR TITLE
Add WP-CLI option for database search-and-replace, curl command for fetching database

### DIFF
--- a/projects/largo/database-reload.md
+++ b/projects/largo/database-reload.md
@@ -9,6 +9,12 @@ $ fab production wp.fetch_sql_dump
 ```
 *Pulls latest from host via SFTP -- requires INN/secrets access.*
 
+If that fails, and if you have the secrets repo set up, you can run:
+
+```
+curl sftp://$LARGOPROJECT_PRODUCTION_SFTP_HOST:2222/wp-content/mysql.sql --user $LARGOPROJECT_PRODUCTION_SFTP_USER:$LARGOPROJECT_PRODUCTION_SFTP_PASSWORD --retry 999 --retry-max-time 0 --remote-name
+```
+
 ### 2. Take vagrant snapshot
 
 Say it with me now
@@ -30,13 +36,36 @@ There are a number of relevant commands here.
 
 ### 4. Replace primary wp_ tables with local environment URLs
 
-Here we update the core WordPress tables for our multisite installation using searchreplacedb2.php.
+There are two ways to do this. The first uses [searchreplacedb2](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/), a PHP script placed in your home directory, and the other uses [WP-CLI](http://wp-cli.org/), a command-line interface for WordPress.
 
-1. We need to open searchreplacedb2.php to perform kosher search and replace. If you're vagrant is up, [use this link](http://vagrant.dev/searchreplacedb2.php).
+#### WP-CLI
+
+```
+$ vagrant up
+$ vagrant ssh
+vagrant@precise64:~$ cd /vagrant
+vagrant@precise64:/vagrant$ wp cli search-replace 'largoproject.wpengine.com' 'vagrant.dev' 'wp_*_options' wp_blogs
+```
+
+That will update all the options tables.
+
+To leave the Vagrant machine, run the following:
+
+```
+vagrant@precise64:/vagrant$ exit
+```
+
+Or skip ahead to Step 5: Recreate your superadmin user
+
+#### searchreplacedb2.php
+
+Here we update the core WordPress tables for our multisite installation using [searchreplacedb2.php](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/).
+
+1. We need to open searchreplacedb2.php to perform kosher search and replace. If your vagrant is up, [use this link](http://vagrant.dev/searchreplacedb2.php).
 2. Leave "Pre-populate the DB values..." checked and submit.
 3. Submit prefilled database information.
 4. WordPress Multisite stores each member site with an ID, which can be seen prefixed in database tables. We want to select **all** the tables (probably at the bottom of the list) **without** numbered prefixes (i.e. wp_comments_meta *not* wp_55_comments_meta) and continue.
-5. Find and Replance
+5. Find and Replace
 
 Replace:
 ```
@@ -47,7 +76,7 @@ With:
 vagrant.dev
 ```
 
-### 5. Recreate your superadmin user
+### 5. Re-create your superadmin user
 
 1. Enter the vagrant directory
 ```


### PR DESCRIPTION
## Changes 
- Add WP-CLI command for database search-and-replace
- Document a `curl` command for fetching the database, assuming INN/secrets

## Why

WP-CLI because it's less effort than searchreplacedb2

curl because the `fab` command frequently fails. 😠 