### PR TITLE
Add Events folder for documentation related to INN events

### DIFF
--- a/events/code-of-conduct.md
+++ b/events/code-of-conduct.md
@@ -1,0 +1,55 @@
+# Code of Conduct for INN Conferences and Meetings
+
+## Short Version
+
+INN is dedicated to a safe, inclusive, welcoming and harassment-free conference experience for everyone.
+
+All attendees, speakers, sponsors and volunteers at INN events are required to abide by the code of conduct.
+
+## Need Help?
+
+Contact any INN staff in person at event, or by email at nerds@inn.org.
+
+## Long Version
+
+INN is committed to providing a welcoming and harassment-free environment for all participants in our conferences, meetings, and other activities, regardless of gender, gender identity, gender expression, sexual orientation, ability, physical appearance, body size, socioeconomic status, race, age, or religion (or lack thereof). In our experience this commitment is shared by the entire community of nonprofit news. We’re articulating this code of conduct not because we expect bad behavior from members of our community but because we believe a clear code of conduct is a necessary part of building a respectful community space.
+
+This code of conduct outlines our expectations for all those who participate in INN events and community interactions, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in INN-hosted activities to help us create safe and positive experiences for everyone.
+
+## Expected Behavior
+
+- Be welcoming, friendly, patient, kind, courteous and respectful.
+- Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+- Be considerate in speech and actions, and actively seek to acknowledge the contributions and respect the boundaries of fellow attendees.
+- Refrain from demeaning, discriminatory, or harassing behavior and speech.
+- Be mindful of your surroundings and of your fellow participants. Alert INN staff if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+- Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+## Unacceptable Behavior
+
+- Violence, threats of violence or violent language directed against another person
+- Sexist, racist, homophobic, transphobic, ableist, or otherwise discriminatory jokes and language
+- Posting or threatening to post other people’s personally identifying information ("doxing")
+- Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability
+- Sustained disruption of community events, including talks and presentations
+- Demeaning, discriminatory, or harassing behavior and speech. Harassment includes, but is not limited to: offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, inappropriate physical contact, and unwelcome sexual attention.
+
+## Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+If any attendee engages in unacceptable behavior, the conference organizers may take any lawful action we deem appropriate, including but not limited to warning the offender or asking the offender to leave the conference. 
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If you feel that someone has harassed you or otherwise treated you inappropriately, please alert any member of the conference team in person, or via email at nerds@inn.org.
+
+If you feel you have been unfairly accused of violating this code of conduct, you should contact the INN team with a concise description of your grievance; any grievances filed will be considered by the INN leadership team.
+
+We welcome your feedback on this and every other aspect of INN, and we thank you for working with us to make participation in our events and community a safe, enjoyable, and friendly experience for everyone.
+
+----
+
+This Code of Conduct is licensed CC BY-SA 4.0. Credit to the SRCCON Code of Conduct, Citizen Code of Conduct, the Conference Code of Conduct, and the Open Source & Feelings Code of Conduct, with general thanks to the Ada Initiative’s “how to design a code of conduct for your community.”

--- a/events/code-of-conduct.md
+++ b/events/code-of-conduct.md
@@ -52,4 +52,4 @@ We welcome your feedback on this and every other aspect of INN, and we thank you
 
 ----
 
-This Code of Conduct is licensed CC BY-SA 4.0. Credit to the SRCCON Code of Conduct, Citizen Code of Conduct, the Conference Code of Conduct, and the Open Source & Feelings Code of Conduct, with general thanks to the Ada Initiative’s “how to design a code of conduct for your community.”
+This Code of Conduct is licensed [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). Credit to the [SRCCON Code of Conduct](http://srccon.org/conduct/), [Citizen Code of Conduct](http://citizencodeofconduct.org/), the [Conference Code of Conduct](http://confcodeofconduct.com/), and the [Open Source & Feelings Code of Conduct](http://www.osfeels.com/conduct/), with general thanks to the [Ada Initiative’s “how to design a code of conduct for your community.”](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/)


### PR DESCRIPTION
## What was done

- Add **Events** folder as container for all docs specifically pertinent to INN events
- Add newly-written doc **Code of Conduct for INN Conferences and Meetings** to the new Events folder

## Why
- We haven't had a place for documentation on INN events and need to begin providing for it in an organized way
- We have an upcoming workshop in Chicago
- We really should provide official policy for INN conferences and events in general