### PR TITLE
Replace Bitbucket with GitHub, update vagrant snapshot references

### DIFF
--- a/projects/largo/umbrella-setup.md
+++ b/projects/largo/umbrella-setup.md
@@ -82,34 +82,11 @@ rm -rf wp-content
 Run the following commands to initialize a new git repository and sync it with the largo-umbrella remote. This is similar to cloning a git repository, but lets us work with the files and folders we already have setup.
 ```
 git init
-git remote add origin git@bitbucket.org:projectlargo/largo-umbrella.git
+git remote add origin git@github.com:INN/umbrella-largoproject.git
 git pull origin master
 ```
 
-Remove the vagrant file previously used by running
-```
-rm Vagrantfile
-```
-
-## 4. Clone the largo-umbrella git repository hosted at BitBucket.
-
-While we use Github for hosting our open source contributions, we use Bitbucket instead for the actual production code that powers our websites. Bitbucket allows for unlimited private repositories for Non-Profits like us, and gives us finer-grained control of permissions to individual projects.
-
-If you haven't already, register a BitBucket account with your INN email address, and then tell Adam that you need access to the [largo-umbrella project](https://bitbucket.org/projectlargo/largo-umbrella). If you're using the command-line interface to git, you'll need to generate an SSH key with `ssh-keygen` and save it to your Bitbucket profile settings as described [here](https://confluence.atlassian.com/display/BITBUCKET/Add+an+SSH+key+to+an+account).
-
-When you have access to the repository, you can now clone it to your local system. The address is `git@bitbucket.org:projectlargo/largo-umbrella.git` which you can clone at the command line with:
-
-```
-$ git clone git@bitbucket.org:projectlargo/largo-umbrella.git
-```
-
-Change directory into the new `largo-umbrella` folder:
-
-```
-$ cd largo-umbrella
-```
-
-## 5. Download git submodules.
+## 4. Download git submodules.
 
 All of the member sites use Largo child themes, which are individually tracked in their own Bitbucket repositories and then linked with the largo-umbrella repository via git submodules. In addition, the INN deploy-tools, some plugins, and the Largo parent theme are included as submodules. Download them now with:
 
@@ -117,7 +94,7 @@ All of the member sites use Largo child themes, which are individually tracked i
 $ git submodule init && git submodule update
 ```
 
-## 6. Install Python tools.
+## 5. Install Python tools.
 
 We use a few Python libraries for this project, including [Fabric](http://www.fabfile.org/) which powers the INN deploy-tools to elegantly run common but complex tasks. In the [OS X setup guide](/staffing/onboarding/os-x-setup.md), you should have installed Python virtualenv and virtualenvwrapper.
 
@@ -137,7 +114,7 @@ $ workon largo-umbrella
 $ pip install -r requirements.txt
 ```
 
-## 7. Verify utility prerequisites.
+## 6. Verify utility prerequisites.
 
 There are a couple other tools that might need to be updated specifically to be able to download from and deploy to the live web sites, production and staging. Now that you have Fabric installed, you can check for those requirements and install them automatically with:
 
@@ -146,7 +123,7 @@ $ fab wp.verify_prerequisites
 ```
 Make sure to have [git-ftp] (https://github.com/git-ftp/git-ftp/blob/develop/INSTALL.md) and the latest version of curl installed. 
 
-## 8. Set up the secrets repository.
+## 7. Set up the secrets repository.
 
 In order to access the live website data, you'll need to set up the INN secrets repository.
 
@@ -173,7 +150,7 @@ In order to access the live website data, you'll need to set up the INN secrets 
 	```
 
 
-## 9.  Create an administrator account for yourself
+## 8.  Create an administrator account for yourself
 
 1. To start, first connect to your virtual machine via ssh using
 
@@ -188,7 +165,7 @@ In order to access the live website data, you'll need to set up the INN secrets 
 
 That's it! Now you can logout of ssh with `exit`
 
-## 10. Take a snapshot of the virtual machine.
+## 9. Take a snapshot of the virtual machine.
 
 Let's take a snapshot of the virtual machine as of this time when the database has just been loaded for the first time. If you make a mistake with the data and remove or modify something you didn't want to, you can revert to a snapshot much more easily than reloading the database.
 
@@ -201,16 +178,16 @@ $ vagrant plugin install vagrant-vbox-snapshot
 Then take your first snapshot with:
 
 ```
-$ vagrant snapshot take default original_database_2015_04_09
+$ vagrant snapshot save original_database_2015_04_09
 ```
 
 You can name the snapshot anything you want, and I would recommend describing it in a short way that describes what that state would give you if you were to revert.
 
-## 11. Get PHP tool for Database Search and Replace.
+## 10. Get PHP tool for Database Search and Replace.
 
 We'll be doing some work soon of searching through the database we just loaded and replacing certain values. To make this easier, download version 2.1.0 of this [database search and replace script written in PHP](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/). Unzip it and move the file `searchreplacedb2.php` to your `largo-umbrella` folder.
 
-## 12. Changing largoproject.wpengine.com to largo-umbrella.dev.
+## 11. Changing largoproject.wpengine.com to largo-umbrella.dev.
 
 There are two ways to do this. The first uses [searchreplacedb2](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/), a PHP script placed in your home directory, and the other uses [WP-CLI](http://wp-cli.org/), a command-line interface for WordPress.
 
@@ -268,7 +245,7 @@ largo-umbrella.dev
 **SNAPSHOT**: Let's save our progress now. In your command line, take another snapshot with:
 
 ```
-$ vagrant snapshot take default after_largoproject_searchandreplace
+$ vagrant snapshot save after_largoproject_searchandreplace
 ```
 
 #### Rock on! But wait, you're not done.
@@ -280,7 +257,7 @@ Each site in the Umbrella requires it's own brief setup before it can be used in
 
 Now you can work with the full Largo-umbrella network of sites locally, with all of the advantages listed at the beginning of this article.
 
-Be sure to take vagrant snapshots liberally when you make changes to the database, as they're a real timesaver in the event of making a mistake or a system crash. My system crashed with no warning while I was writing this up, and when I tried starting my virtual machine again I got an error that the virtual machine image was corrupted. I was saved a whole lot of work because I was able to just revert to the latest snapshot I had made (`vagrant snapshot go original_database_2015_04_09`).
+Be sure to take vagrant snapshots liberally when you make changes to the database, as they're a real timesaver in the event of making a mistake or a system crash. My system crashed with no warning while I was writing this up, and when I tried starting my virtual machine again I got an error that the virtual machine image was corrupted. I was saved a whole lot of work because I was able to just revert to the latest snapshot I had made (`vagrant snapshot restore original_database_2015_04_09`).
 
 ### You may need to [reload the database](../database-reload.md) at some point 
 

--- a/projects/largo/umbrella-setup.md
+++ b/projects/largo/umbrella-setup.md
@@ -30,71 +30,26 @@ Let's get the latest version of the WordPress database that powers the live, pro
 
 **NOTE**: Access to the INN/secrets repo is required.
 
-Do that with:
-```
-$ fab production wp.fetch_sql_dump
-```
 
-Go make another cup of tea, or two. At the time of this writing, the SQL dump file was 3.1 GB. This will take at least an hour.
+## 2. Create a new WordPress install for the largoproject site  using VV
+
+Follow the instructions in the largoproject repository: https://github.com/INN/umbrella-largoproject/blob/master/README.md
+
+When those instructions ask you to run `fab production wp.fetch_sql_dump`, go make another cup of tea, or two. At the time of this writing, the SQL dump file was 3.1 GB. This will take at least an hour. If the download fails:
+
+1. Run `ls *.sql` to find SQL files in your local directory
+2. For the largest SQL file, run `tail largest.sql`
+3. If the output of that command does not end with `-- Dump completed`, do one of the following:
+	- ask someone else for their vagrant copy of the database
+	- download it via a different SFTP client
+
+When running `fab vagrant.reload_db:mysql.sql`, if you receive an error, try running the command that fab would run manually. Common causes of errors are:
+
+- `mysql` is not installed on the host computer
+- The vagrant machine needs to have its version of mysql updated: https://github.com/INN/deploy-tools/issues/51
 
 
-
-
-## 2. Create a new site using VV
-
-Run the following command from your vagrant root to initiate the vv site creation wizard:
-
-```
-vv create
-```
-
-Follow the prompts, entering the information below, or hitting [Enter] to skip.
-
-Prompt | Text to enter 
------------- | -------------
-Name of new site directory: | largo-umbrella 
-Blueprint to use (leave blank for none or use largo): | *hit [Enter]* 
-Blueprint to use (leave blank for none or use largo): | *hit [Enter]*
-Domain to use (leave blank for largo-umbrella.dev): | *hit [Enter]*
-WordPress version to install (leave blank for latest version or trunk for trunk/nightly version): | *hit [Enter]*
-Install as multisite? (y/N): | y 
-Install as subdomain or subdirectory? : | subdomain 
-Git repo to clone as wp-content (leave blank to skip): | *hit [Enter]*
-Local SQL file to import for database (leave blank to skip): | *This directory must be an absolute path, so the easiest thing to do is to drag your mysql file into your terminal window here and the absolute filepath with fill itself in.*
-Remove default themes and plugins? (y/N): | N 
-Add sample content to site (y/N): | N 
-Enable WP_DEBUG and WP_DEBUG_LOG (y/N): | y
- 
-This will take a few minutes to build your new site and load in the database, so be patient.
-
-## 3. Add the Largo Umbrella files to your new site
-
-First, lets navigate to our new install using 
-```
-cd www/largo-umbrella/htdocs
-```
-
-Remove default wp-content folder
-```
-rm -rf wp-content
-```
-
-Run the following commands to initialize a new git repository and sync it with the largo-umbrella remote. This is similar to cloning a git repository, but lets us work with the files and folders we already have setup.
-```
-git init
-git remote add origin git@github.com:INN/umbrella-largoproject.git
-git pull origin master
-```
-
-## 4. Download git submodules.
-
-All of the member sites use Largo child themes, which are individually tracked in their own Bitbucket repositories and then linked with the largo-umbrella repository via git submodules. In addition, the INN deploy-tools, some plugins, and the Largo parent theme are included as submodules. Download them now with:
-
-```
-$ git submodule init && git submodule update
-```
-
-## 5. Install Python tools.
+## 3. Install Python tools.
 
 We use a few Python libraries for this project, including [Fabric](http://www.fabfile.org/) which powers the INN deploy-tools to elegantly run common but complex tasks. In the [OS X setup guide](/staffing/onboarding/os-x-setup.md), you should have installed Python virtualenv and virtualenvwrapper.
 
@@ -114,7 +69,7 @@ $ workon largo-umbrella
 $ pip install -r requirements.txt
 ```
 
-## 6. Verify utility prerequisites.
+## 4. Verify utility prerequisites.
 
 There are a couple other tools that might need to be updated specifically to be able to download from and deploy to the live web sites, production and staging. Now that you have Fabric installed, you can check for those requirements and install them automatically with:
 
@@ -123,7 +78,7 @@ $ fab wp.verify_prerequisites
 ```
 Make sure to have [git-ftp] (https://github.com/git-ftp/git-ftp/blob/develop/INSTALL.md) and the latest version of curl installed. 
 
-## 7. Set up the secrets repository.
+## 5. Set up the secrets repository.
 
 In order to access the live website data, you'll need to set up the INN secrets repository.
 
@@ -150,7 +105,7 @@ In order to access the live website data, you'll need to set up the INN secrets 
 	```
 
 
-## 8.  Create an administrator account for yourself
+## 6.  Create an administrator account for yourself
 
 1. To start, first connect to your virtual machine via ssh using
 
@@ -165,7 +120,7 @@ In order to access the live website data, you'll need to set up the INN secrets 
 
 That's it! Now you can logout of ssh with `exit`
 
-## 9. Take a snapshot of the virtual machine.
+## 7. Take a snapshot of the virtual machine.
 
 Let's take a snapshot of the virtual machine as of this time when the database has just been loaded for the first time. If you make a mistake with the data and remove or modify something you didn't want to, you can revert to a snapshot much more easily than reloading the database.
 
@@ -183,11 +138,11 @@ $ vagrant snapshot save original_database_2015_04_09
 
 You can name the snapshot anything you want, and I would recommend describing it in a short way that describes what that state would give you if you were to revert.
 
-## 10. Get PHP tool for Database Search and Replace.
+## 8. Get PHP tool for Database Search and Replace.
 
 We'll be doing some work soon of searching through the database we just loaded and replacing certain values. To make this easier, download version 2.1.0 of this [database search and replace script written in PHP](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/). Unzip it and move the file `searchreplacedb2.php` to your `largo-umbrella` folder.
 
-## 11. Changing largoproject.wpengine.com to largo-umbrella.dev.
+## 9. Changing largoproject.wpengine.com to largo-umbrella.dev.
 
 There are two ways to do this. The first uses [searchreplacedb2](https://interconnectit.com/products/search-and-replace-for-wordpress-databases/), a PHP script placed in your home directory, and the other uses [WP-CLI](http://wp-cli.org/), a command-line interface for WordPress.
 


### PR DESCRIPTION
# Changes

- Removes duplicate section about cloning Bitbucket, points to the Largo Umbrella's setup docs
- Replaces references to `vagrant snapshot take` with `vagrant snapshot save` to reflect recent versions of the snapshot plugin. https://www.vagrantup.com/docs/cli/snapshot.html
- Adds some common initial setup gotchas