### PR TITLE
Add a little more guidance to the newsletter contributor email

### DIFF
--- a/communications/newsletter/editor-responsibilities.md
+++ b/communications/newsletter/editor-responsibilities.md
@@ -16,6 +16,8 @@ And then for each newsletter:
 - [ ] Complete all of the tasks in the [pre-publish checklist](/checklists/newsletter.md)
 
 - [ ] Add newsletter content to the blog as a draft (reference the [blog post checklist](/checklists/blog-post.md) for more details)
+	- [ ] if the post has a guest contributor, tag it 'guest'
+	- [ ] put it in the "Newsletter" category
 
 - [ ] Newsletter sent via MailChimp by 2 p.m. CT on Friday
 

--- a/communications/newsletter/sample-contributor-email.md
+++ b/communications/newsletter/sample-contributor-email.md
@@ -12,7 +12,9 @@ All we need is:
 - A link to the best thing you read this week and a couple sentences on what it is, why it grabbed your attention and why you think other people should read it
 - Optional: a photo (doesn't need to be very big, square is best)
 
-By Thursday, [DATE] at 3 pm CT.
+You can see examples of past guest contributions at https://nerds.inn.org/tag/guest
+
+We would need your contribution by Thursday, [DATE] at 3 pm CT.
 
 Please let us know at nerds@inn.org as soon as possible if you're interested and able to contribute. We're excited to hear from you!
 

--- a/communications/newsletter/sample-contributor-email.md
+++ b/communications/newsletter/sample-contributor-email.md
@@ -2,19 +2,19 @@ Hi there,
 
 The INN News Apps and Technology team sends out a weekly newsletter every Friday called "Nerd Alert" where we share the best things we've read each week.
 
-Each week we choose a guest contributor to share something that caught their attention that week and we'd love to have you be our "guest star" this week.
+Each week we seek a guest contributor to share something that caught their attention that week and we'd love to have you be our "guest star" this week.
 
 All we need is:
 
 - Your name as you want it to appear in the newsletter
-- Your title/organization (where applicable)
+- Your title/organization (where applicable) or a few words about what you do
 - Twitter handle, if you want us to include it
-- A link to the best thing you read this week and a couple sentences on what it is, why it grabbed your attention and why you think other people should read it.
+- A link to the best thing you read this week and a couple sentences on what it is, why it grabbed your attention and why you think other people should read it
 - Optional: a photo (doesn't need to be very big, square is best)
 
 By Thursday, [DATE] at 3 pm CT.
 
-Please let us know ASAP if you're interested and able to contribute. We're excited to hear from you!
+Please let us know at nerds@inn.org as soon as possible if you're interested and able to contribute. We're excited to hear from you!
 
 Best,
 The INN Nerds

--- a/projects/book-club/readme.md
+++ b/projects/book-club/readme.md
@@ -1,16 +1,16 @@
 # INN Nerds Book Club
 
-Once a month, we'll pick a book, read it and host a public Google Hangout to discuss it. Unless we're at a conference or otherwise need to change the date, the meetings will be at 1pm ET on the second Wednesday of each month.
+Every other month, we'll pick a book, read it and host a public Zoom call to discuss it. Unless we're at a conference or otherwise need to change the date, the meetings will be at 1pm ET on the second Wednesday of each month.
 
 Here's [our original announcement](http://nerds.inn.org/2014/09/02/come-learn-with-us-announcing-the-news-nerd-book-club/) of the program describing why we're doing this and what we hope to accomplish.
 
-To pick which book gets read each month, we'll take suggestions via [@newsnerdbooks](https://twitter.com/newsnerdbooks) or in-person at the end of each book club meeting. We maintain [a running list of book suggestions](https://Hackpad.com/News-Nerd-Book-Club-Reading-List-YAApSL79SO2) on Hackpad. At the end of each meeting we'll discuss some options and the book club facilitator will choose a book for the next book club meeting.
+To pick which book gets read each month, we'll take suggestions via [@newsnerdbooks](https://twitter.com/newsnerdbooks) or in-person at the end of each book club meeting. We maintain [a running list of book suggestions](https://docs.google.com/document/d/116BA_bNSVpckcfP26JVTHK5g6UR6KSZrkwil5xxcQmg/edit?usp=sharing) on Google Drive. At the end of each meeting we'll discuss some options and the book club facilitator will choose a book for the next book club meeting.
 
 Once a book is selected, we'll let everyone know which book made the cut on our Twitter account, [@newsnerdbooks](https://twitter.com/newsnerdbooks) a post on the [team's blog](http://nerds.inn.org/) in the "book club" category and by creating a Google+ event from the [primary INN Google+ page](https://plus.google.com/+InvestigativenewsnetworkOrg/posts) (more on that in a minute).
 
 You can find all of our [past book club books and blog posts here](http://nerds.inn.org/category/book-club/).
 
-For remote meetings (most months) we need to create a persistent link to a public Google Hangout. To do that, we need to create a Google Plus event listing, which will include a link to the public Google Hangout where the discussion will happen. This listing should be public by default and created from the INN Google+ page by following [these instructions](/projects/tools.md#google-hangouts).
+For remote meetings (most months) we need to create a persistent link to a public Zoom call.
 
 For in-person meetings (likely a couple times a year at conferences) we'll create an Eventbrite listing with details so people can RSVP because we'll need a rough count to make sure we choose an appropriate venue.
 


### PR DESCRIPTION
## Changes

- improves title/job description guidance for newsletter guests
- adds how to send contributions to us
- adds taxonomy term recommendations for newsletter posts on the Nerds blog

## Why

Because we're not consistent about tagging guest content as "guest".

Because sometimes it's easier to send someone a link to the newsletter contributor sample email, rather than sending them the email