### PR TITLE
Create docs folder for keeping track of dependencies

### DIFF
--- a/projects/dependencies/CMB2.md
+++ b/projects/dependencies/CMB2.md
@@ -1,0 +1,11 @@
+# CMB2
+
+repo: https://github.com/CMB2/CMB2/
+
+announcements: https://github.com/CMB2/CMB2/releases
+
+## Developer Driven Custom Post Classes
+
+repo: https://github.com/INN/developer-driven-custom-post-classes/
+
+update procedure: something involving `yo plugin-wp`?

--- a/projects/dependencies/README.md
+++ b/projects/dependencies/README.md
@@ -1,0 +1,9 @@
+# Dependencies folder
+
+This folder should contain a list of project dependencies, where the following are true:
+
+1. the dependency is directly embedded in the project, as opposed to being served via a CDN, loaded with `npm` or `composer` or `pip`, or installed globally on the machine running the software. Embedded dependencies' code is tracked directly in the same repository as the project using it.
+	- [Pym.js](blog.apps.npr.org/pym.js/) loaded via the CDN should not be here.
+	- Pym.js files kept in the repository should be listed here.
+	- Pym.js files uploaded somewhere for a project, but not actively tracked in that project's repo, should be listed here.
+2. the dependency is not a software-as-a-service API that we expect to continue existing. This list includes non-beta products of the following companies: Amazon AWS, Google Drive.

--- a/projects/dependencies/README.md
+++ b/projects/dependencies/README.md
@@ -7,3 +7,11 @@ This folder should contain a list of project dependencies, where the following a
 	- Pym.js files kept in the repository should be listed here.
 	- Pym.js files uploaded somewhere for a project, but not actively tracked in that project's repo, should be listed here.
 2. the dependency is not a software-as-a-service API that we expect to continue existing. This list includes non-beta products of the following companies: Amazon AWS, Google Drive.
+
+Each dependency file should:
+
+- Provide a place where update announcements can be acquired
+- Provide a list of projects that depend upon the dependency, with the following information
+	- project name
+	- project repository or location
+	- update instructions for this dependency

--- a/projects/dependencies/pym.js.md
+++ b/projects/dependencies/pym.js.md
@@ -22,11 +22,3 @@ pym update instructions:
 2. run `fab assets.sync`
 3. replace the copy of pym.js acquired by running `fab assets.sync` with the latest copy of pym.js
 4. run `fab assets.sync` to upload the local copy.
-
-## INN Discounts Page
-
-status:
-
-repo: none; https://labs.inn.org/wp-content/uploads/static/discounts/
-
-pym update instructions: do it via SFTP

--- a/projects/dependencies/pym.js.md
+++ b/projects/dependencies/pym.js.md
@@ -1,0 +1,32 @@
+# Pym.js
+
+The following projects maintained by INN depend on Pym.js:
+
+## Pym Shortcode
+
+status: maintained
+
+repo: https://github.com/INN/pym-shortcode
+
+pym update instructions: https://github.com/INN/pym-shortcode/blob/master/docs/updating-pym.md
+
+## Power Players
+
+status: not maintained
+
+repo: https://github.com/INN/power-players
+
+pym update instructions:
+
+1. set up the repo on your computer, including Fabric and AWS Credentials.
+2. run `fab assets.sync`
+3. replace the copy of pym.js acquired by running `fab assets.sync` with the latest copy of pym.js
+4. run `fab assets.sync` to upload the local copy.
+
+## INN Discounts Page
+
+status:
+
+repo: none; https://labs.inn.org/wp-content/uploads/static/discounts/
+
+pym update instructions: do it via SFTP

--- a/projects/dependencies/release.sh.md
+++ b/projects/dependencies/release.sh.md
@@ -1,0 +1,7 @@
+# release.sh
+
+Docs: https://github.com/INN/docs/blob/master/projects/wordpress-plugins/release.sh.md
+
+repo: https://github.com/INN/docs/blob/master/projects/wordpress-plugins/release.sh
+
+List of plugins using release.sh: https://github.com/INN/docs/blob/master/projects/wordpress-plugins/release.sh.md#plugins-using-releasesh


### PR DESCRIPTION
## Changes

- adds a folder for keeping track of projects by their dependencies
- adds respective dependency files for CMB2, pym.js, and release.sh. release.sh is just a pointer to the list of plugins in release.sh.md elsewhere in this repository, though.

## Why

Basically: to make it easier to track down pym.js projects in the event of another security vulnerability disclosure like https://blog.apps.npr.org/2018/02/15/pym-security-vulnerability.html