### PR TITLE
Update team staff list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ We welcome contributions and suggestions to help us improve any of these documen
 
 The INN news apps and technology team is:
 
--  **[Ben Keith](https://github.com/benlk)** ([@benlkeith](http://twitter.com/benlkeith)), News Apps Developer
--  **[RC Lations](https://github.com/rclations)** ([@rclations](https://twitter.com/rclations)), Lead Developer
--  **[Kay Lima](https://github.com/kaylima)** ([@kayleen_lima](http://twitter.com/kayleen_lima)), Support and Community Lead
 -  **[Julia Smith](https://github.com/julia67)** ([@julia67](https://twitter.com/julia67)), Director, Product & Technology
+-  **[Ben Keith](https://github.com/benlk)** ([@benlkeith](http://twitter.com/benlkeith)), News Apps Developer
+-  **[Kay Lima](https://github.com/kaylima)** ([@kayleen_lima](http://twitter.com/kayleen_lima)), Support and Community Lead
+-  **[Tyler Machado](https://github.com/tylermachado)** ([@tylermachado](https://twitter.com/tylermachado)), Front-End Developer
 
 **Head Nerd emeritus:** **[Adam Schweigert](https://github.com/aschweigert)** ([@aschweig](http://twitter.com/aschweig))
 
-**Nerds emeriti:** [Nick Bennett](https://github.com/tothebeat), [Jack Brighton](http://github.com/jackbrighton), [Will Haynes](https://github.com/willhaynes), [Kaeti Hinck](https://github.com/kaeti), [Gabriel Hongsdusit](https://github.com/gabehong), [Dani Litovsky Alcalá](https://github.com/danilito19), [Denise Malan](https://github.com/dnmalan), [Meredith Melragon](https://github.com/meredithinn), [Ryan Nagle](https://github.com/rnagle), [Sinduja Rangarajan](https://github.com/cynduja), [David Ryan](https://github.com/dryanmedia)
+**Nerds emeriti:** [Nick Bennett](https://github.com/tothebeat), [Jack Brighton](http://github.com/jackbrighton), [Will Haynes](https://github.com/willhaynes), [Kaeti Hinck](https://github.com/kaeti), [Gabriel Hongsdusit](https://github.com/gabehong), [Dani Litovsky Alcalá](https://github.com/danilito19), [Denise Malan](https://github.com/dnmalan), [Meredith Melragon](https://github.com/meredithinn), [Ryan Nagle](https://github.com/rnagle), [Sinduja Rangarajan](https://github.com/cynduja), [David Ryan](https://github.com/dryanmedia), [RC Lations](https://github.com/rclations)
 
 **Additional contributions from:** [@chriszs](https://github.com/chriszs) and [@brentajones](https://github.com/brentajones)
 


### PR DESCRIPTION
## Changes:

- Move RC to Nerds Emeriti
- Add Tyler Machado
- Move Julia to the top of the list, 'cos she's director