### PR TITLE
Release.sh docs: additional info for later releases

### DIFF
--- a/projects/wordpress-plugins/release.sh.md
+++ b/projects/wordpress-plugins/release.sh.md
@@ -8,17 +8,30 @@ This file provides setup, usage, and configuration instructions for `release.sh`
 
 1. Review the files in the `BLACKLIST` variable in `release.sh`. Make changes as necessary.
 2. Update the `SVN_REPO` variable with your plugin's `plugins.svn.wordpress.org` SVN repository.
-3. `chmod +x release.sh`
-4. Add `release/` to the project's `.gitignore`
-5. Commit all changes and push your commits to the plugin's repository.
-
-6. Run `release.sh`.
+3. `chmod +x release.sh`.
+4. Add `release/` to the project's `.gitignore`>
+5. Commit all changes.
+6. Tag your new release using `git tag`.
+7. `git push` your commits and `git push --tags` your tags to the plugin's repository.
+8. Run `release.sh`.
   - You may need to verify the receiving server's key fingerprint.
   - If it asks you to enter the password for your computer's username, press the `[enter]` key to get the username prompt, then enter your `wordpress.org` username and password.
 
 ### Later releases
 
-1. Run `release.sh`
+1. Commit all changes.
+2. Make sure that you have bumped the version number in:
+	- `readme.txt`
+	- `README.md`
+	- the plugin's primary `.php` file
+3. Make sure that you have also updated:
+	- `Tested up to:` WordPress version number in `readme.txt`
+	- `Requires at least:` WordPress version number in `readme.txt`
+	- `Requires PHP:` minimum PHP version number in `readme.txt`
+	- `Changelog` section in `readme.txt`
+2. Tag your new release using `git tag`.
+3. `git push` your commits and `git push --tags` your tags to the plugin's repository.
+4. Run `release.sh`.
 
 ### Generating zip files for GitHub
 
@@ -57,4 +70,4 @@ This list may be incomplete.
 - https://github.com/INN/link-roundups
 - https://github.com/INN/super-cool-ad-inserter-plugin
 
-Significant changes to `release.sh` should be copied between plugins.
+Significant changes to `release.sh` should be copied between plugins, and merged into this repository.

--- a/projects/wordpress-plugins/release.sh.md
+++ b/projects/wordpress-plugins/release.sh.md
@@ -35,6 +35,8 @@ This file provides setup, usage, and configuration instructions for `release.sh`
 
 ### Common issues
 
+
+#### no remote configured
 ```
 $ ./release.sh
 fatal: No remote configured to list refs from.
@@ -44,6 +46,37 @@ Make sure you've checked out a tag or the master branch before releasing.
 ```
 
 Make sure that one of your remotes is named `origin`.
+
+#### "forbidden" when committing
+
+```
+Committing release/svn/tags/1.7 (slow) ...
+Authentication realm: <https://plugins.svn.wordpress.org:443> Use your WordPress.org login
+Password for 'user': 
+svn: E195023: Commit failed (details follow):
+svn: E195023: Changing directory '/Users/local_username/sites/example/wp-content/plugins/PLUGIN-NAME/release/svn/tags/1.7' is forbidden by the server
+svn: E175013: Access to '/!svn/txr/RANDOM-CHARACTERS/PLUGIN-NAME/tags/1.7' forbidden
+```
+
+A possible cause of this is that your WordPress.org account does not have commit access. Check to make sure that your WordPress user has the "committer" role on wordpress.org for this plugin, as [described in the Plugin Handbook](https://developer.wordpress.org/plugins/wordpress-org/special-user-roles-capabilities/).
+
+#### certificate error
+
+```
+Error validating server certificate for 'https://plugins.svn.wordpress.org:443':
+ - The certificate is not issued by a trusted authority. Use the
+   fingerprint to validate the certificate manually!
+Certificate information:
+ - Hostname: *.svn.wordpress.org
+ - Valid: from Fri, 12 Jun 2015 17:44:41 GMT until Sun, 15 Jul 2018 19:04:26 GMT
+ - Issuer: http://certs.godaddy.com/repository/, GoDaddy.com, Inc., Scottsdale, Arizona, US
+ - Fingerprint: 5c:f0:21:33:a0:f1:f6:37:ac:06:87:c8:62:03:08:d0:32:50:6f:77
+(R)eject, accept (t)emporarily or accept (p)ermanently? p
+```
+
+According to https://make.wordpress.org/core/handbook/tutorials/installing-wordpress-locally/from-svn/#1-2-using-command-line the accepted solution is "Type `p` to accept it permanently."
+
+###
 
 ### Generating zip files for GitHub
 

--- a/projects/wordpress-plugins/release.sh.md
+++ b/projects/wordpress-plugins/release.sh.md
@@ -33,6 +33,18 @@ This file provides setup, usage, and configuration instructions for `release.sh`
 3. `git push` your commits and `git push --tags` your tags to the plugin's repository.
 4. Run `release.sh`.
 
+### Common issues
+
+```
+$ ./release.sh
+fatal: No remote configured to list refs from.
+fatal: No remote configured to list refs from.
+Bad release state for git repo!
+Make sure you've checked out a tag or the master branch before releasing.
+```
+
+Make sure that one of your remotes is named `origin`.
+
 ### Generating zip files for GitHub
 
 GitHub's default release `.zip` files do not contain files installed by package management systems through commands like `npm install`, `bower install`, and `composer install`.


### PR DESCRIPTION
## Changes

- better setup instructions for first-time configuration of `release.sh`
- more-complete checklist for releasing plugins at later times
- common failure/error modes of `release.sh`