### PR TITLE
Onboarding: add addition of new staff to the team weekly responsibilities list

### DIFF
--- a/staffing/onboarding/onboarding-checklist.md
+++ b/staffing/onboarding/onboarding-checklist.md
@@ -25,6 +25,8 @@
   - [ ] Dropbox
   - [ ] Google Drive
   - [ ] Shared Google Calendars
+- [ ] Responsibilities lists
+  - [ ] https://docs.google.com/spreadsheets/d/1akpzhzJ8r2e43X-s7Y9LJIydJiffQ-D8VifjIQqQKjc/edit
 - [ ] 1password
   - Install app
   - Invite to INN team/shared vault (https://innorg.1password.com)


### PR DESCRIPTION
If we're using the team weekly responsibilities list to track weekly responsibilities list, we should have new staff add themselves to that list.