### PR TITLE
Replace 404'd links to tribapps blog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ These docs draw on (and sometimes straight up steal) excellent work from teams t
 
 - [ProPublica's News App and Data Style Guides](https://github.com/propublica/guides)
 - The NPR Visuals Team's [app template](https://github.com/nprapps/app-template), [coding best practices](https://github.com/nprapps/bestpractices) and [manifesto](http://blog.apps.npr.org/2014/06/04/how-we-work.html)
-- [Guides](https://github.com/newsapps/guides) and [Process Docs](http://blog.apps.chicagotribune.com/2014/03/05/everything-you-ever-wanted-to-know-about-the-news-apps-process/) from The Chicago Tribune's News Apps Team
+- [Guides](https://github.com/newsapps/guides) and [Process Docs](https://web.archive.org/web/20160909203500/http://blog.apps.chicagotribune.com/2014/03/05/everything-you-ever-wanted-to-know-about-the-news-apps-process/) from The Chicago Tribune's News Apps Team
 - [MinnPost's UI Style Guide](https://github.com/MinnPost/minnpost-styles)
 
 [<img src="https://www.browserstack.com/images/layout/browserstack-logo-600x315.png" width=250 />](https://browserstack.com)

--- a/how-to-work-with-us/readme.md
+++ b/how-to-work-with-us/readme.md
@@ -13,7 +13,7 @@ Everything you need to know about the services we offer and how to work with us 
 
 From Chicago Tribune:
 
--  [Everything you ever wanted to know about the News Apps process](http://blog.apps.chicagotribune.com/2014/03/05/everything-you-ever-wanted-to-know-about-the-news-apps-process)
+-  [Everything you ever wanted to know about the News Apps process](https://web.archive.org/web/20160909203500/http://blog.apps.chicagotribune.com/2014/03/05/everything-you-ever-wanted-to-know-about-the-news-apps-process/)
 -  [Detailed process doc](https://docs.google.com/document/d/1dDcu-IM1nO5x86iY38OQc9O8UliJHUOXXNSFfoWxd8E/edit)
 -  [Sample intake doc](https://docs.google.com/document/d/1m-JD39DBKMoFO1zTaV8_ZANVHySJr8YxHyekdxRGb5E/edit)
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Replaces old Chicago Tribune Apps blog links with archived version supplied by @aschweigert 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Resolves https://github.com/INN/docs/issues/225.

## Testing/Questions

Steps to test this PR:

1. Click the link?