### PR TITLE
Improvements to WP Plugins section of docs

### DIFF
--- a/projects/wordpress-plugins/_template.md
+++ b/projects/wordpress-plugins/_template.md
@@ -1,9 +1,14 @@
 # Plugin name
 
-GitHub repo: https://github.com/inn/
-wordpress.org plugin repo: https://wordpress.org/plugins/
-status: &#128128; retired
+Status: &#128128; retired
 
-## Description:
+## Relevant links:
+
+- GitHub repo: https://github.com/inn/
+- Wordpress.org plugin repo: https://wordpress.org/plugins/
+
+## What is it?
 
 Historical information should go in this area of the file.
+
+## Who made it?

--- a/projects/wordpress-plugins/_template.md
+++ b/projects/wordpress-plugins/_template.md
@@ -1,0 +1,8 @@
+# Plugin name
+
+GitHub repo: https://github.com/inn/
+wordpress.org plugin repo: https://wordpress.org/plugins/
+
+## Description:
+
+Historical information should go in this area of the file.

--- a/projects/wordpress-plugins/_template.md
+++ b/projects/wordpress-plugins/_template.md
@@ -2,6 +2,7 @@
 
 GitHub repo: https://github.com/inn/
 wordpress.org plugin repo: https://wordpress.org/plugins/
+status: &#128128; retired
 
 ## Description:
 

--- a/projects/wordpress-plugins/client-hosting-manager.md
+++ b/projects/wordpress-plugins/client-hosting-manager.md
@@ -1,0 +1,21 @@
+# Client Hosting Manager
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/inn/client-hosting-manager
+- Wordpress.org plugin repo: https://wordpress.org/plugins/client-hosting-manager/
+- Instructions on removal: https://github.com/INN/umbrella-currentorg/issues/17
+
+## What is it?
+
+Once upon a time, many INN member sites were all hosted as part of a single multisite WordPress install. And many users on those sites had admin access. WordPress single-site admins could still update plugins, but we didn't want them to be able to do that, because it would affect sites other than their own. Thus, we needed to selectively remove certain permissions from users who were not INN staff, which are documented [in the plugin's readme](https://github.com/INN/client-hosting-manager/blob/master/README.md)
+
+Users of this plugin would need to define several constants which would determine which users were allowed to have which permissions by matching those users' email address domains.
+
+If the plugin were removed from a site without first deactivating it while the constants were set, the plugin's permissions changes would remain permanently. The problems can be fixed with [`wp cap`](https://developer.wordpress.org/cli/commands/cap/).
+
+## Who made it?
+
+RC Lations, Ben Keith

--- a/projects/wordpress-plugins/credentials.md
+++ b/projects/wordpress-plugins/credentials.md
@@ -1,0 +1,19 @@
+# Credentials
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/credentials
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+Collects information about post authors and displays that information in widgets.
+
+For a more up-to-date version, check out [Trust Indicators](trust-indicators.md).
+
+
+## Who made it?
+
+This plugin was created as a part of the Trust Project Challenge hosted by the BBC Connected Studio in Fall 2016 as a collaboration between INN and BBC team members. RC Lations led the effort.

--- a/projects/wordpress-plugins/developer-driven-custom-post-classes.md
+++ b/projects/wordpress-plugins/developer-driven-custom-post-classes.md
@@ -1,0 +1,11 @@
+# Developer-Driven Custom Post Classes
+
+GitHub repo: https://github.com/INN/developer-driven-custom-post-classes
+wordpress.org plugin repo: not published
+
+## Description:
+
+Uses CMB2 to add a meta box allowing drop-down selection of theme-developer-defined custom classes on a post.
+
+Developer-Driven Custom Post Classes was originally [written for Chicago Reporter](https://github.com/INN/umbrella-chicagoreporter/blob/master/wp-content/themes/chicago-reporter/inc/DDCPC.php), and was subsequently used on other sites, including [Mississippi Today](https://github.com/INN/umbrella-mstoday/blob/master/wp-content/themes/mstoday/inc/DDCPC.php).
+

--- a/projects/wordpress-plugins/developer-driven-custom-post-classes.md
+++ b/projects/wordpress-plugins/developer-driven-custom-post-classes.md
@@ -2,6 +2,7 @@
 
 GitHub repo: https://github.com/INN/developer-driven-custom-post-classes
 wordpress.org plugin repo: not published
+Status: ?
 
 ## Description:
 

--- a/projects/wordpress-plugins/inn-members.md
+++ b/projects/wordpress-plugins/inn-members.md
@@ -1,0 +1,16 @@
+# INN Members
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/inn-members
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+Largo-independent implementation of the INN Member Stories widget, the INN Members dashboard widget, and an analytics package. This dates to the 2017 work on Largo 1.0, which among other work involved splitting Largo into separately-installable pieces that could be used by INN members who weren't running Largo.
+
+## Who made it?
+
+RC Lations.

--- a/projects/wordpress-plugins/knight-lab-storytelling-tools.md
+++ b/projects/wordpress-plugins/knight-lab-storytelling-tools.md
@@ -1,0 +1,21 @@
+# Knight Lab Storytelling Tools
+
+Status: 
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/storytelling-tools
+- Wordpress.org plugin repo: https://wordpress.org/plugins/storytelling-tools/
+- Knight's pages: https://knightlab.northwestern.edu/projects/
+
+## What is it?
+
+This plugin adds support for embedding various of Knight Lab's projects in WordPress in a way that won't get stripped by wp_kses:
+- [Timeline](http://timeline.knightlab.com/)
+- [StoryMap](https://storymap.knightlab.com/)
+- [Juxtapose](https://juxtapose.knightlab.com/)
+- [Soundcite](http://soundcite.knightlab.com/)
+
+## Who made it?
+
+RC Lations, Ben Keith, Kay Lima, Adam Schweigert.

--- a/projects/wordpress-plugins/largo-clean-contact.md
+++ b/projects/wordpress-plugins/largo-clean-contact.md
@@ -1,0 +1,18 @@
+# Largo Clean Contact
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/largo-clean-contact
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+Modifications to the [Clean Contact](https://wordpress.org/plugins/clean-contact/) plugin, used for contact forms on Largo sites.
+
+It was later included directly in Largo at https://github.com/INN/largo/tree/v0.6.4/lib/clean-contact
+
+## Who made it?
+
+Adam Schweigert

--- a/projects/wordpress-plugins/link-roundups.md
+++ b/projects/wordpress-plugins/link-roundups.md
@@ -17,3 +17,4 @@ This is one of the plugins we adopted from NPR's Project Argo but it has since b
 - [Plugin repository on GitHub](https://github.com/INN/link-roundups)
 - [Plugin listing on wordpress.org](https://wordpress.org/plugins/link-roundups/)
 - [WordPress MailChimp tools](https://github.com/INN/wordpress-mailchimp-tools/tree/12225e55f2bbe7fff3baf2d93d4c1b5b83c0f316) (used for MailChimp integration)
+- [NPR Argo Project original documentation](http://argoproject.org/argo-links.php.html)

--- a/projects/wordpress-plugins/navis-documentcloud.md
+++ b/projects/wordpress-plugins/navis-documentcloud.md
@@ -1,0 +1,19 @@
+# Navis DocumentCloud
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/navis-documentcloud
+- NPR Project Argo docs: http://argoproject.org/documentcloud.php.html
+
+## What is it?
+
+A shortcode for [DocumentCloud](https://www.documentcloud.org/) embeds.
+
+Rather than using this, you should use [the official DocumentCloud plugin](https://wordpress.org/plugins/documentcloud/), whose github repo is https://github.com/documentcloud/wordpress-documentcloud
+
+
+## Who made it?
+
+Originally, NPR, as part of their [StateImpact project](https://stateimpact.npr.org/).

--- a/projects/wordpress-plugins/navis-jiffy-posts.md
+++ b/projects/wordpress-plugins/navis-jiffy-posts.md
@@ -1,0 +1,16 @@
+# Navis Jiffy Posts
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/navis-jiffy-posts
+- NPR Argo Project docs: http://argoproject.org/jiffy-post.php.html
+
+## What is it?
+
+Originally by NPR, this plugin aimed to make it easier to embed new content on your site.
+
+## Who made it?
+
+NPR and Daniel Bachhuber.

--- a/projects/wordpress-plugins/navis-media-credit.md
+++ b/projects/wordpress-plugins/navis-media-credit.md
@@ -6,6 +6,7 @@ Status: &#128128; retired
 
 - GitHub repo: https://github.com/INN/navis-media-credit
 - Wordpress.org plugin repo: none
+- NPR Project Argo docs: http://argoproject.org/media-credit.php.html
 
 ## What is it?
 

--- a/projects/wordpress-plugins/navis-media-credit.md
+++ b/projects/wordpress-plugins/navis-media-credit.md
@@ -1,0 +1,20 @@
+# Navis Media Credit
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/navis-media-credit
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+Part of NPR's original Argo Project, Navis Media Credit adds fields to the image uploader to set an individual image credit, organization credit, and organization credit URL.
+
+Now included in Largo at https://github.com/INN/largo/tree/v0.6.4/lib/navis-media-credit
+
+A separate implementation exists at https://github.com/Automattic/newspack-image-credits
+
+## Who made it?
+
+NPR, and Adam Schweigert, and some other contributors. Primary development continues in Largo.

--- a/projects/wordpress-plugins/navis-slideshows.md
+++ b/projects/wordpress-plugins/navis-slideshows.md
@@ -1,0 +1,18 @@
+# Navis Slideshows
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/navis-slideshows
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+Originally developed by NPR for the Argo Project, this plugin hooks the [post_gallery](https://developer.wordpress.org/reference/hooks/post_gallery/) filter to augment the output of the `[gallery]` shortcode and turn it into a slideshow.
+
+Later incorporated into Largo at https://github.com/INN/largo/tree/trunk/lib/navis-slideshows and substantially rewritten.
+
+## Who made it?
+
+NPR, Adam Schweigert, and other contributors.

--- a/projects/wordpress-plugins/navis-slideshows.md
+++ b/projects/wordpress-plugins/navis-slideshows.md
@@ -5,7 +5,7 @@ Status: &#128128; retired
 ## Relevant links:
 
 - GitHub repo: https://github.com/INN/navis-slideshows
-- Wordpress.org plugin repo: none
+- NPR Argo Project docs: http://argoproject.org/slideshow.php.html
 
 ## What is it?
 

--- a/projects/wordpress-plugins/news-match-donation-shortcode.md
+++ b/projects/wordpress-plugins/news-match-donation-shortcode.md
@@ -1,13 +1,20 @@
 # News Match Donation Shortcode
 
-GitHub repo: https://github.com/INN/news-match-donation-shortcode
-wordpress.org plugin repo: https://wordpress.org/plugins/news-match-donation-shortcode/
 status: &#128128; retired
 
-## Description:
+## Relevant links:
+
+GitHub repo: https://github.com/INN/news-match-donation-shortcode
+wordpress.org plugin repo: https://wordpress.org/plugins/news-match-donation-shortcode/
+
+## What is it?
 
 Created for News Match 2017 to make it easy for sites to place a News Revenue Hub donation form without fighting wp_kses.
 
 This plugin inherited some code from [okwatch-donation](https://github.com/INN/okwatch-donation) and [rivard-donation-plugin](https://github.com/INN/rivard-donation-plugin/), and superseded them.
 
 https://inn.org/event/inn-labs-presents-wordpress-tools-for-your-news-match-campaign/
+
+## Who made it?
+
+Voice of San Diego, Ben Keith, Julia Smith, RC Lations 

--- a/projects/wordpress-plugins/news-match-donation-shortcode.md
+++ b/projects/wordpress-plugins/news-match-donation-shortcode.md
@@ -1,0 +1,13 @@
+# News Match Donation Shortcode
+
+GitHub repo: https://github.com/INN/news-match-donation-shortcode
+wordpress.org plugin repo: https://wordpress.org/plugins/news-match-donation-shortcode/
+status: &#128128; retired
+
+## Description:
+
+Created for News Match 2017 to make it easy for sites to place a News Revenue Hub donation form without fighting wp_kses.
+
+This plugin inherited some code from [okwatch-donation](https://github.com/INN/okwatch-donation) and [rivard-donation-plugin](https://github.com/INN/rivard-donation-plugin/), and superseded them.
+
+https://inn.org/event/inn-labs-presents-wordpress-tools-for-your-news-match-campaign/

--- a/projects/wordpress-plugins/news-match-popup-basics.md
+++ b/projects/wordpress-plugins/news-match-popup-basics.md
@@ -1,0 +1,11 @@
+# News Match Popup Basics
+
+GitHub repo: https://github.com/INN/news-match-popup-plugin
+wordpress.org plugin repo: https://wordpress.org/plugins/news-match-popup-basics/
+status: &#128128; retired
+
+## Description:
+
+Created for News Match 2017 to give sites an easy way to create a [Popup Maker](https://wordpress.org/plugins/popup-maker/) popup with the recommended default settings for News Match.
+
+https://inn.org/event/inn-labs-presents-wordpress-tools-for-your-news-match-campaign/

--- a/projects/wordpress-plugins/news-match-popup-basics.md
+++ b/projects/wordpress-plugins/news-match-popup-basics.md
@@ -1,11 +1,18 @@
 # News Match Popup Basics
 
-GitHub repo: https://github.com/INN/news-match-popup-plugin
-wordpress.org plugin repo: https://wordpress.org/plugins/news-match-popup-basics/
 status: &#128128; retired
 
-## Description:
+## Relevant Links
+
+GitHub repo: https://github.com/INN/news-match-popup-plugin
+wordpress.org plugin repo: https://wordpress.org/plugins/news-match-popup-basics/
+
+## What is it?
 
 Created for News Match 2017 to give sites an easy way to create a [Popup Maker](https://wordpress.org/plugins/popup-maker/) popup with the recommended default settings for News Match.
 
 https://inn.org/event/inn-labs-presents-wordpress-tools-for-your-news-match-campaign/
+
+## Who made it?
+
+Ben Keith

--- a/projects/wordpress-plugins/no-nonsense-google-analytics.md
+++ b/projects/wordpress-plugins/no-nonsense-google-analytics.md
@@ -1,0 +1,18 @@
+# No Nonsense Google Analytics
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/no-nonsense-google-analytics/
+- Wordpress.org plugin repo: https://wordpress.org/plugins/no-nonsense-google-analytics/
+
+## What is it?
+
+A simple Universal Analytics implementation of Google Analytics. No dashboard, no reports.
+
+Intended to replace Largo's built-in Analytics.
+
+## Who made it?
+
+RC Lations.

--- a/projects/wordpress-plugins/npr-audio-player.md
+++ b/projects/wordpress-plugins/npr-audio-player.md
@@ -1,0 +1,16 @@
+# NPR Audio Player
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/npr-audio-player
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+Adds an audio player widget, supporting 3 streams.
+
+## Who made it?
+
+Julia Smith

--- a/projects/wordpress-plugins/pmp-distribution.md
+++ b/projects/wordpress-plugins/pmp-distribution.md
@@ -1,0 +1,17 @@
+# Public Media Platform Distribution Extension
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/pmp-distribution
+- Wordpress.org plugin repo: none
+- Related plugin: [Public Media Platform](./public-media-platform.md)
+
+## What is it?
+
+This plugin extends the PMP plugin to provide additional metaboxes and user roles for a PMP concept called a "distributor" who can determine what collections a PMP document (a WordPress Post) is in.
+
+## Who made it?
+
+Ryan Nagle

--- a/projects/wordpress-plugins/public-media-platform.md
+++ b/projects/wordpress-plugins/public-media-platform.md
@@ -1,6 +1,15 @@
 # Public Media Platform
 
-### What is it?
+Status: &#128128; retired
+
+## Relevant links:
+
+- [Plugin repository on GitHub](https://github.com/publicmediaplatform/pmp-wordpress)
+- [Plugin listing on WordPress.org](https://wordpress.org/plugins/public-media-platform/)
+- [Public Media Platform website](http://publicmediaplatform.org/)
+
+
+## What is it?
 
 The [Public Media Platform](http://publicmediaplatform.org/) is a cross-media distribution system for digital content (audio, video, stories, and images). You can use it both to bring additional public media produced content to your site, and to expand the reach of your content to external web and mobile destinations.
 
@@ -10,12 +19,7 @@ The Public Media Platform is now [a project of NPR Digital Services](http://publ
 
 INN was hired to build the official WordPress plugin for the platform.
 
-### Who made it?
+## Who made it?
 
 Ryan Nagle (for the Public Media Platform)
 
-### Relevant links:
-
-- [Plugin repository on GitHub](https://github.com/publicmediaplatform/pmp-wordpress)
-- [Plugin listing on WordPress.org](https://wordpress.org/plugins/public-media-platform/)
-- [Public Media Platform website](http://publicmediaplatform.org/)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -24,6 +24,7 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 
 - [Google Analytics Popular Posts](google-analytics-popular-posts.md)
 - [INN Members](inn-members.md)
+- [Knight Lab Storytelling Tools](knight-lab-storytelling-tools.md)
 - [Largo Clean Contact](largo-clean-contact.md)
 - [NPR Audio Player](npr-audio-player.md)
 - [Navis DocumentCloud](navis-documentcloud.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -26,6 +26,8 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 - [INN Members](inn-members.md)
 - [Largo Clean Contact](largo-clean-contact.md)
 - [NPR Audio Player](npr-audio-player.md)
+- [Navis DocumentCloud](navis-documentcloud.md)
+- [Navis Jiffy Posts](navis-jiffy-posts.md)
 - [Navis Media Credits](navis-media-credit.md)
 - [Navis Slideshows](navis-slideshows.md)
 - [News Match Donation Shortcode](news-match-donation-shortcode.md) (rivard, okwatch donation shortcodes)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -14,6 +14,7 @@ Some plugins we have built and maintain include:
 - [Super Cool Ad Manager Plugin](doubleclick-for-wp.md)
 - [Super Cool Ad Inserter](super-cool-ad-inserter.md)
 - [Link Roundups](link-roundups.md)
+- [Trust Indicators](trust-indicators.md)
 
 Plugins which are neither maintained nor not-maintained:
 
@@ -28,6 +29,8 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 - [Term Debt Consolidator](term-debt-consolidator.md)
 - [News Match Donation Shortcode](news-match-donation-shortcode.md) (rivard, okwatch donation shortcodes)
 - [News Match Popup Basics](news-match-popup-basics.md)
+- [NPR Audio Player](npr-audio-player.md)
+- [INN Members](inn-members.md)
 
 To add a plugin to this list, copy [`_template.md`](_template.md) into a new file.
 

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -23,6 +23,7 @@ Plugins which are neither maintained nor not-maintained:
 
 We no longer maintain these plugins, but their docs are being kept here as a historical reference:
 
+- [Client Hosting Manager](client-hosting-manager.md)
 - [Credentials](credentials.md)
 - [Google Analytics Popular Posts](google-analytics-popular-posts.md)
 - [INN Members](inn-members.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -15,6 +15,7 @@ Some plugins we have built and maintain include:
 - [Super Cool Ad Inserter](super-cool-ad-inserter.md)
 - [Link Roundups](link-roundups.md)
 - [Trust Indicators](trust-indicators.md)
+- [Republication Tracker Tool](republication-tracker-tool.md)
 
 Plugins which are neither maintained nor not-maintained:
 

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -23,6 +23,8 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 - [News Quiz](news-quiz.md)
 - [Google Analytics Popular Posts](google-analytics-popular-posts.md)
 - [Term Debt Consolidator](term-debt-consolidator.md)
+- [News Match Donation Shortcode](news-match-donation-shortcode.md) (rivard, okwatch donation shortcodes)
+- [News Match Popup Basics](news-match-popup-basics.md)
 
 To add a plugin to this list, copy [`_template.md`](_template.md) into a new file.
 

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -29,6 +29,7 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 - [INN Members](inn-members.md)
 - [Knight Lab Storytelling Tools](knight-lab-storytelling-tools.md)
 - [Largo Clean Contact](largo-clean-contact.md)
+- [Largo Related Posts](largo-related-posts.md)
 - [NPR Audio Player](npr-audio-player.md)
 - [Navis DocumentCloud](navis-documentcloud.md)
 - [Navis Jiffy Posts](navis-jiffy-posts.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -4,15 +4,22 @@ In addition to our work on [Largo](/projects/largo/), our team has created a num
 
 ### Plugins
 
-- [DoubleClick for WordPress](doubleclick-for-wp.md)
-- [Google Analytics Popular Posts](google-analytics-popular-posts.md)
-- [Link Roundups](link-roundups.md)
-- [News Quiz](news-quiz.md)
-- [Public Media Platform](public-media-platform.md)
-- [Pym Shortcode](pym-shortcode.md)
+You can find [the current list of maintained plugins at support.inn.org](https://support.inn.org/category/202-plugins-by-inn-labs).
+
+Some plugins we have built and maintain include:
+
+- [Pym.js Embeds](pym-shortcode.md)
+- [Super Cool Ad Manager Plugin](doubleclick-for-wp.md)
 - [Super Cool Ad Inserter](super-cool-ad-inserter.md)
+- [Link Roundups](link-roundups.md)
+
+We no longer maintain these plugins, but their docs are being kept here as a historical reference:
+
+- [Public Media Platform](public-media-platform.md)
+- [News Quiz](news-quiz.md)
+- [Google Analytics Popular Posts](google-analytics-popular-posts.md)
 - [Term Debt Consolidator](term-debt-consolidator.md)
 
 ### Utilities
 
-- [Plugin release script](release.sh.md) (for wordpress.org)
+- [Plugin release script](release.sh.md) (for wordpress.org plugins)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -6,6 +6,8 @@ In addition to our work on [Largo](/projects/largo/), our team has created a num
 
 You can find [the current list of maintained plugins at support.inn.org](https://support.inn.org/category/202-plugins-by-inn-labs).
 
+Some plugins in this list may have private, archived, or deleted repositories, and consequently may not be visible.
+
 Some plugins we have built and maintain include:
 
 - [Pym.js Embeds](pym-shortcode.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -20,6 +20,7 @@ Plugins which are neither maintained nor not-maintained:
 We no longer maintain these plugins, but their docs are being kept here as a historical reference:
 
 - [Public Media Platform](public-media-platform.md)
+- [Public Media Platform Distribution Extension](pmp-distribution.md)
 - [News Quiz](news-quiz.md)
 - [Google Analytics Popular Posts](google-analytics-popular-posts.md)
 - [Term Debt Consolidator](term-debt-consolidator.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -22,18 +22,21 @@ Plugins which are neither maintained nor not-maintained:
 
 We no longer maintain these plugins, but their docs are being kept here as a historical reference:
 
-- [Public Media Platform](public-media-platform.md)
-- [Public Media Platform Distribution Extension](pmp-distribution.md)
-- [News Quiz](news-quiz.md)
 - [Google Analytics Popular Posts](google-analytics-popular-posts.md)
-- [Term Debt Consolidator](term-debt-consolidator.md)
+- [INN Members](inn-members.md)
+- [Largo Clean Contact](largo-clean-contact.md)
+- [NPR Audio Player](npr-audio-player.md)
 - [News Match Donation Shortcode](news-match-donation-shortcode.md) (rivard, okwatch donation shortcodes)
 - [News Match Popup Basics](news-match-popup-basics.md)
-- [NPR Audio Player](npr-audio-player.md)
-- [INN Members](inn-members.md)
+- [News Quiz](news-quiz.md)
+- [Public Media Platform Distribution Extension](pmp-distribution.md)
+- [Public Media Platform](public-media-platform.md)
+- [RNS Transmissions](rns-transmissions.md)
+- [Term Debt Consolidator](term-debt-consolidator.md)
 
 To add a plugin to this list, copy [`_template.md`](_template.md) into a new file.
 
 ### Utilities
 
 - [Plugin release script](release.sh.md) (for wordpress.org plugins)
+- [WordPress MailChimp Tools](wordpress-mailchimp-tools.md) (library)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -33,6 +33,7 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 - [News Match Donation Shortcode](news-match-donation-shortcode.md) (rivard, okwatch donation shortcodes)
 - [News Match Popup Basics](news-match-popup-basics.md)
 - [News Quiz](news-quiz.md)
+- [No Nonsense Google Analytics](no-nonsense-google-analytics.md)
 - [Public Media Platform Distribution Extension](pmp-distribution.md)
 - [Public Media Platform](public-media-platform.md)
 - [RNS Transmissions](rns-transmissions.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -22,6 +22,7 @@ Plugins which are neither maintained nor not-maintained:
 
 We no longer maintain these plugins, but their docs are being kept here as a historical reference:
 
+- [Credentials](credentials.md)
 - [Google Analytics Popular Posts](google-analytics-popular-posts.md)
 - [INN Members](inn-members.md)
 - [Knight Lab Storytelling Tools](knight-lab-storytelling-tools.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -26,6 +26,8 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 - [INN Members](inn-members.md)
 - [Largo Clean Contact](largo-clean-contact.md)
 - [NPR Audio Player](npr-audio-player.md)
+- [Navis Media Credits](navis-media-credit.md)
+- [Navis Slideshows](navis-slideshows.md)
 - [News Match Donation Shortcode](news-match-donation-shortcode.md) (rivard, okwatch donation shortcodes)
 - [News Match Popup Basics](news-match-popup-basics.md)
 - [News Quiz](news-quiz.md)

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -13,12 +13,18 @@ Some plugins we have built and maintain include:
 - [Super Cool Ad Inserter](super-cool-ad-inserter.md)
 - [Link Roundups](link-roundups.md)
 
+Plugins which are neither maintained nor not-maintained:
+
+- [Developer-Driven Custom Post Classes](developer-driven-custom-post-classes)
+
 We no longer maintain these plugins, but their docs are being kept here as a historical reference:
 
 - [Public Media Platform](public-media-platform.md)
 - [News Quiz](news-quiz.md)
 - [Google Analytics Popular Posts](google-analytics-popular-posts.md)
 - [Term Debt Consolidator](term-debt-consolidator.md)
+
+To add a plugin to this list, copy [`_template.md`](_template.md) into a new file.
 
 ### Utilities
 

--- a/projects/wordpress-plugins/readme.md
+++ b/projects/wordpress-plugins/readme.md
@@ -43,6 +43,7 @@ We no longer maintain these plugins, but their docs are being kept here as a his
 - [Public Media Platform](public-media-platform.md)
 - [RNS Transmissions](rns-transmissions.md)
 - [Term Debt Consolidator](term-debt-consolidator.md)
+- [Term Enhancements](term-enhancements.md)
 
 To add a plugin to this list, copy [`_template.md`](_template.md) into a new file.
 

--- a/projects/wordpress-plugins/republication-tracker-tool.md
+++ b/projects/wordpress-plugins/republication-tracker-tool.md
@@ -1,0 +1,23 @@
+# Republication Tracker Tool
+
+Status: Maintained!
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/republication-tracker-tool
+- Wordpress.org plugin repo: https://wordpress.org/plugins/republication-tracker-tool/
+- Documentation: https://github.com/INN/republication-tracker-tool/blob/master/docs/README.md
+- Documentation: https://support.inn.org/category/313-republication-tracker-tool-plugin
+
+## What is it?
+
+Provides:
+- a sharing button that opens a modal
+- a modal that provides information about this site's sharing policy
+- a way to copy the text of a story to facilitate pasting it into other sites' CMSes
+- a tracking bug in the form of an `img` tag
+- an image URL that redirects through a hit counter, which tracks hits and referers within WordPress and by sending hits to Google Analytics to track republished articles from external websites.
+
+## Who made it?
+
+RC Lations, Julia Smith, Ben Keith, Josh Darby, and contributors like you.

--- a/projects/wordpress-plugins/republication-tracker-tool.md
+++ b/projects/wordpress-plugins/republication-tracker-tool.md
@@ -1,6 +1,6 @@
 # Republication Tracker Tool
 
-Status: Maintained!
+Status: Maintained?
 
 ## Relevant links:
 
@@ -9,7 +9,10 @@ Status: Maintained!
 - Documentation: https://github.com/INN/republication-tracker-tool/blob/master/docs/README.md
 - Documentation: https://support.inn.org/category/313-republication-tracker-tool-plugin
 
+
 ## What is it?
+
+Republication Tracker Tool began life as the "Creative Commons Sharing" plugin, which provided a means to facilitate sharing the content of a post under a Creative Commons license. RTT extends that with a tracking mechanism similar to ProPublica's [PixelPing](https://www.propublica.org/pixelping). RTT's tracker is presented to the reader as the logo of the site of original publication, but on the server side is a redirect to an image file, which logs information about the referrer to Google Analytics and the publishing site's database as post meta.
 
 Provides:
 - a sharing button that opens a modal
@@ -18,6 +21,16 @@ Provides:
 - a tracking bug in the form of an `img` tag
 - an image URL that redirects through a hit counter, which tracks hits and referers within WordPress and by sending hits to Google Analytics to track republished articles from external websites.
 
+
 ## Who made it?
 
-RC Lations, Julia Smith, Ben Keith, Josh Darby, and contributors like you.
+RC Lations did a lot of the initial work, with support from Julia Smith. Since then, it's been mostly Ben Keith and Josh Darby, with some outside support from INN members.
+
+## Things to know
+
+This plugin powers republication buttons on sites that don't use the plugin's own code for outputting the share modal. Be cautious about deprecating existing code.
+
+Known examples:
+
+- https://19thnews.org/2020/08/black-women-economy-coronavirus-systemic-racism/?republish
+- https://ohiocapitaljournal.com/briefs/operation-grant-seeks-to-turn-republicans-toward-biden-in-election/

--- a/projects/wordpress-plugins/rns-transmissions.md
+++ b/projects/wordpress-plugins/rns-transmissions.md
@@ -1,0 +1,16 @@
+# Religion News Service Transmissions
+
+Status: &#128128; retired
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/rns-transmissions
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+A plugin to produce the "Transmissions" newsletters from Religion News Service, building on INN's [wordpress-mailchimp-tools](https://github.com/INN/wordpress-mailchimp-tools) component. Includes a custom post template.
+
+## Who made it?
+
+Ryan Nagle, RC Lations

--- a/projects/wordpress-plugins/term-debt-consolidator.md
+++ b/projects/wordpress-plugins/term-debt-consolidator.md
@@ -1,5 +1,12 @@
 # Term Debt Consolidator
 
+Status: ?
+
+### Relevant links:
+
+- [Plugin repo on GitHub](https://github.com/INN/term-debt-consolidator)
+- [Listing on wordpress.org](https://wordpress.org/plugins/term-debt-consolidator/) 
+
 ### What is it?
 
 Term Debt Consolidator can look at your WordPress site's tags and categories to suggest areas for consolidation and deletion and help you identify ways to improve your use of WordPress' taxonomy functionality.
@@ -9,9 +16,3 @@ Additionally, the plugin allows you to add any custom taxonomies your site might
 ### Who made it?
 
 Ryan Nagle (originally for [Women's eNews](http://womensenews.org))
-
-
-### Relevant links:
-
-- [Plugin repo on GitHub](https://github.com/INN/term-debt-consolidator)
-- [Listing on wordpress.org](https://wordpress.org/plugins/term-debt-consolidator/) 

--- a/projects/wordpress-plugins/trust-indicators.md
+++ b/projects/wordpress-plugins/trust-indicators.md
@@ -1,0 +1,22 @@
+# Trust Indicators
+
+Status:
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/trust-indicators
+- Wordpress.org plugin repo: none
+
+## What is it?
+
+This plugin stores and displays information related to:
+
+- articles
+- authors
+- the publishing organization
+
+This plugin was funded by and built in collaboration with [the Trust Project](https://thetrustproject.org/).
+
+## Who made it?
+
+RC Lations, Julia Smith, Kay Lima, Josh Darby, and contributors from Trust Project member organizations.

--- a/projects/wordpress-plugins/wordpress-mailchimp-tools.md
+++ b/projects/wordpress-plugins/wordpress-mailchimp-tools.md
@@ -1,0 +1,16 @@
+# WordPress MailChimp Tools
+
+Status: 
+
+## Relevant links:
+
+- GitHub repo: https://github.com/INN/wordpress-mailchimp-tools
+- Wordpress.org plugin repo: not a plugin!
+
+## What is it?
+
+This library provides functions to make it easier to integrate the MailChimp API with WordPress. It's primarily used in our [Link Roundups plugin](link-roundups.md).
+
+## Who made it?
+
+Ryan Nagle, RC Lations, Ben Keith


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Links out to Helpscout page with list of currently-maintained plugins
- Separates plugin list between maintained and not
- Keeps old-plugin docs around as a historical reference
- Adds new old-plugin docs for more historical references:
    - Developer-Driven Custom Post Classes
    - News Match Donation Shortcode
    - News Match Popup Basics
    - PMP Distribution

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #234

## Testing/Questions

Features that this PR affects:

- /projects/wordpress-plugins/ readme

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Should we try to make this a more-comprehensive list of past and present plugins, with links to all relevant docs including wp.org, Github, support.inn.org, and the status of the plugin?

Steps to test this PR:

1. View https://github.com/INN/docs/tree/234-sunsetting-plugins/projects/wordpress-plugins