### PR TITLE
instructions for using a new device

### DIFF
--- a/projects/wordpress-plugins/release.sh.md
+++ b/projects/wordpress-plugins/release.sh.md
@@ -16,6 +16,15 @@ This file provides setup, usage, and configuration instructions for `release.sh`
 8. Run `release.sh`.
   - You may need to verify the receiving server's key fingerprint.
   - If it asks you to enter the password for your computer's username, press the `[enter]` key to get the username prompt, then enter your `wordpress.org` username and password.
+  
+### Using a new device with an existing plugin repository
+1. Review the files in the `BLACKLIST` variable in `release.sh`. Make changes as necessary.
+2. Update the `SVN_REPO` variable with your plugin's `plugins.svn.wordpress.org` SVN repository.
+3. `chmod +x release.sh`.
+4. `mkdir release`.
+5. `svn co https://plugins.svn.wordpress.org/plugin-slug/ release` to make the `release` directory. 
+6. `cd ..` to get back to the root of the plugin.
+7. Run `release.sh`.
 
 ### Later releases
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- adds instructions for using `release.sh` on a new device with a plugin repository that already exists

## Why

I'm always forgetting how to re-add the SVN repository, but if it's not there the release.sh file will throw errors.

## Testing/Questions

Features that this PR affects:

- release.sh

## Additional information

INN Member/Labs Client requesting: MinnPost

- [x] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] Contributor would like to be mentioned in the release notes as: jonathanstegall
- [x] Contributor agrees to the license terms of this repository.
